### PR TITLE
Set commit_version_number to true

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,7 @@ jobs:
     if: ${{ github.event.pull_request.merged }}
     name: 🏗️ Build package and publish to pypi
     runs-on: ubuntu-latest
+    concurrency: build
     steps:
       - name: ⬇️ Checkout repository
         uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "niceml"
 version = "0.1.1"
-description = "Welcome to niceML 🍦, a Python-based MLOps framework that uses TensorFlow and Dagster. This framework streamlines the development, and maintenance of machine learning models, providing an end-to-end solution for building efficient and scalable pipelines. You will find detailed documentation, tutorials, and examples in this repository."
+description = "Welcome to niceML 🍦, a Python-based MLOps framework that uses TensorFlow and Dagster. This framework streamlines the development, and maintenance of machine learning models, providing an end-to-end solution for building efficient and scalable pipelines."
 authors = [
     "Denis Stalz-John <denis.stalz-john@codecentric.de>",
     "Nils Uhrberg <nils.uhrberg@codecentric.de>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ version_toml = [
 ]
 
 version_source="tag"
+commit_version_number = true
 major_on_zero = false
 branch = "main"
 upload_to_PyPI = true


### PR DESCRIPTION
- Set the concurrency of the build step to `build` (name of the job) so that only one workflow instance can build a release at a time
- Semantic release configuration adjusted so that version changes are transferred.