### PR TITLE
Expand numbers dataset with tabular data

### DIFF
--- a/configs/jobs/job_data_generation/job_data_generation.yaml
+++ b/configs/jobs/job_data_generation/job_data_generation.yaml
@@ -6,6 +6,8 @@ defaults:
   - ops/split_data@ops.split_data.config: op_split_data_number.yaml
   # op for cropping numbers from images and store them in a separate folder
   - ops/crop_numbers@ops.crop_numbers.config: op_crop_numbers.yaml
+  # op to save images as tabular data
+  - ops/image_to_tabular_data@ops.image_to_tabular_data.config: op_image_to_tabular_data.yaml
   # credentials are only used for data location, otherwise ignored
   - /shared/credentials@globals.data_location.credentials: credentials_minio.yaml
   - _self_

--- a/configs/ops/image_to_tabular_data/op_image_to_tabular_data.yaml
+++ b/configs/ops/image_to_tabular_data/op_image_to_tabular_data.yaml
@@ -1,7 +1,8 @@
 clear_folder: True
 output_location: ${globals.data_location}
 sub_dir: numbers_tabular_data
-target_image_shape:
+target_image_size:
   _target_: niceml.utilities.imagesize.ImageSize
   width: 10
   height: 10
+use_dirs_as_subsets: True

--- a/configs/ops/image_to_tabular_data/op_image_to_tabular_data.yaml
+++ b/configs/ops/image_to_tabular_data/op_image_to_tabular_data.yaml
@@ -1,0 +1,7 @@
+clear_folder: True
+output_location: ${globals.data_location}
+sub_dir: numbers_tabular_data
+target_image_shape:
+  _target_: niceml.utilities.imagesize.ImageSize
+  width: 10
+  height: 10

--- a/niceml/dagster/jobs/jobs.py
+++ b/niceml/dagster/jobs/jobs.py
@@ -7,6 +7,7 @@ from niceml.dagster.ops.datageneration import data_generation
 from niceml.dagster.ops.evalcopyexp import eval_copy_exp
 from niceml.dagster.ops.experiment import experiment
 from niceml.dagster.ops.exptests import exptests
+from niceml.dagster.ops.imagetotable import image_to_tabular_data
 from niceml.dagster.ops.localizeexperiment import localize_experiment
 from niceml.dagster.ops.prediction import prediction
 from niceml.dagster.ops.splitdata import split_data
@@ -17,16 +18,17 @@ from dagster import job
 
 @job(config=hydra_conf_mapping)
 def job_data_generation():
-    """job for data generation"""
+    """Job for data generation"""
 
     output_loc = data_generation()  # pylint: disable=no-value-for-parameter
     output_loc = split_data(output_loc)  # pylint: disable=no-value-for-parameter
-    crop_numbers(output_loc)  # pylint: disable=no-value-for-parameter
+    output_loc = crop_numbers(output_loc)  # pylint: disable=no-value-for-parameter
+    image_to_tabular_data(output_loc)
 
 
 @job(config=hydra_conf_mapping)
 def job_train():
-    """job for training an experiment"""
+    """Job for training an experiment"""
     exp_context = experiment()  # pylint: disable=no-value-for-parameter
     exp_context = train(exp_context)  # pylint: disable=no-value-for-parameter
     exp_context = prediction(exp_context)  # pylint: disable=no-value-for-parameter
@@ -36,7 +38,7 @@ def job_train():
 
 @job(config=hydra_conf_mapping)
 def job_eval():
-    """job for evaluating experiment"""
+    """Job for evaluating experiment"""
     exp_context = localize_experiment()  # pylint: disable=no-value-for-parameter
     exp_context = eval_copy_exp(exp_context)  # pylint: disable=no-value-for-parameter
     exp_context = prediction(exp_context)  # pylint: disable=no-value-for-parameter
@@ -51,5 +53,5 @@ def job_eval():
     },
 )
 def job_copy_exp():
-    """Copies an experiment from one location to another"""
+    """Copy an experiment from one location to another"""
     copy_exp()  # pylint: disable=no-value-for-parameter

--- a/niceml/utilities/imagegeneration.py
+++ b/niceml/utilities/imagegeneration.py
@@ -1,7 +1,7 @@
 """Module for functions to generate test image dataset"""
 from copy import copy
 from dataclasses import dataclass
-from hashlib import md5
+from hashlib import sha256
 from os.path import join
 from pathlib import Path
 from typing import List, Tuple, Union, Optional
@@ -234,7 +234,7 @@ def generate_number_image(  # noqa: PLR0913
             raise AttributeError(
                 "You have to pass a file_path if you want to save the image"
             )
-        file_name: str = md5(img.tobytes()).hexdigest()[:8]
+        file_name: str = sha256(img.tobytes()).hexdigest()[:8]
         with open_location(location) as (cur_fs, root_path):
             write_image(img, join(root_path, file_name + ".png"), cur_fs)
             write_image(mask_img, join(root_path, f"{file_name}_mask.png"), cur_fs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ mdx-include = "^1.4.2"
 mkdocs = "^1.4.3"
 
 [tool.ruff]
+select = ["E","F","D100", "D101","D102", "D103", "D104","D105","D106","D107","PT","PL"]
+fixable = ["E","F","D","PT","PL"]
+exclude = ["./tests/**"]
 line-length = 100
 
 [build-system]

--- a/tests/unit/niceml/utilities/test_imagegeneration.py
+++ b/tests/unit/niceml/utilities/test_imagegeneration.py
@@ -1,6 +1,6 @@
 from pathlib import Path
+from typing import Optional, Tuple
 
-import numpy as np
 from PIL import Image, ImageDraw
 
 from niceml.utilities.boundingboxes.bboxlabeling import (
@@ -17,6 +17,11 @@ from niceml.utilities.imagesize import ImageSize
 from niceml.utilities.imageutils import get_font
 from niceml.utilities.splitutils import clear_folder
 from tests.unit.niceml.data.conftest import objdet_image_label_path
+
+import numpy as np
+import pytest
+
+from niceml.utilities.imagegeneration import convert_image_to_df_row
 
 
 def test_single_image_generation():
@@ -99,3 +104,55 @@ def test_crop_text_layer_to_text():
     text_layer = crop_text_layer_to_text(text_layer)
 
     assert (57, 87) == text_layer.size
+
+
+@pytest.mark.parametrize(
+    "identifier, label, image, target_size, expected_output",
+    [
+        (
+            "test_image",
+            "positive",
+            np.zeros((4, 4), dtype=np.uint8),
+            (2, 2),
+            {
+                "identifier": "test_image",
+                "label": "positive",
+                "px_0_0": 0,
+                "px_0_1": 0,
+                "px_1_0": 0,
+                "px_1_1": 0,
+            },
+        ),
+        (
+            "test_image_2",
+            "negative",
+            np.ones((3, 3), dtype=np.uint8),
+            None,
+            {
+                "identifier": "test_image_2",
+                "label": "negative",
+                "px_0_0": 1,
+                "px_0_1": 1,
+                "px_0_2": 1,
+                "px_1_0": 1,
+                "px_1_1": 1,
+                "px_1_2": 1,
+                "px_2_0": 1,
+                "px_2_1": 1,
+                "px_2_2": 1,
+            },
+        ),
+    ],
+)
+def test_convert_image_to_df_row(
+    identifier: str,
+    label: str,
+    image: np.ndarray,
+    target_size: Optional[Tuple],
+    expected_output: dict,
+):
+    # call the function with the test data
+    df_row = convert_image_to_df_row(identifier, label, image, target_size)
+
+    # check the output
+    assert df_row == expected_output


### PR DESCRIPTION
- Added new op that converts the cropped images of the numbers dataset into tabular values
- Add function to convert an image into a dataframe and also add tests 
- The dataframe (tabular data) has the following form

| identifier | label | px_0_0 | px_0_1 | ... |
| --- | --- | ---  | --- | --- |

- First detailed ruff  configuration 
   - Configure pylint and pydoc

> Note
> To disable a pylint rule, the comment `# noqa: <Rule_ID>` can be used

- Remove md5 hash due to [CWE-327](https://cwe.mitre.org/data/definitions/327.html)