### PR TITLE
Add lockfile name as attribute of FileChecksumProcessor

### DIFF
--- a/niceml/filechecksumprocessors/filechecksumprocessor.py
+++ b/niceml/filechecksumprocessors/filechecksumprocessor.py
@@ -26,6 +26,7 @@ class FileChecksumProcessor(ABC):
         input_location: Union[dict, LocationConfig],
         output_location: Union[dict, LocationConfig],
         lockfile_location: Union[dict, LocationConfig],
+        lock_file_name: str = "lock.yaml",
         debug: bool = False,
         process_count: int = 8,
         batch_size: int = 16,
@@ -41,6 +42,7 @@ class FileChecksumProcessor(ABC):
             process_count: Amount of processes for parallel execution
             batch_size: Size of a batch
         """
+        self.lock_file_name = lock_file_name
         self.input_location = input_location
         self.output_location = output_location
         self.lockfile_location = lockfile_location
@@ -54,7 +56,7 @@ class FileChecksumProcessor(ABC):
         with open_location(self.lockfile_location) as (lockfile_fs, lockfile_path):
             try:
                 checksum_dict = read_yaml(
-                    join_fs_path(lockfile_fs, lockfile_path, "lock.yaml"),
+                    join_fs_path(lockfile_fs, lockfile_path, self.lock_file_name),
                     file_system=lockfile_fs,
                 )
             except FileNotFoundError:
@@ -149,7 +151,7 @@ class FileChecksumProcessor(ABC):
                 ):
                     write_yaml(
                         dict(self.lock_data),
-                        join_fs_path(lockfile_fs, lockfile_root, "lock.yaml"),
+                        join_fs_path(lockfile_fs, lockfile_root, self.lock_file_name),
                         file_system=lockfile_fs,
                     )
 

--- a/niceml/filechecksumprocessors/zippedcsvtoparqprocessor.py
+++ b/niceml/filechecksumprocessors/zippedcsvtoparqprocessor.py
@@ -30,6 +30,7 @@ class ZippedCsvToParqProcessor(FileChecksumProcessor):
         input_location: Union[dict, LocationConfig],
         output_location: Union[dict, LocationConfig],
         lockfile_location: Union[dict, LocationConfig],
+        lock_file_name: str = "lock.yaml",
         debug: bool = False,
         process_count: int = 8,
         batch_size: int = 16,
@@ -53,12 +54,13 @@ class ZippedCsvToParqProcessor(FileChecksumProcessor):
                         searched for files recursively
         """
         super().__init__(
-            input_location,
-            output_location,
-            lockfile_location,
-            debug,
-            process_count,
-            batch_size,
+            input_location=input_location,
+            output_location=output_location,
+            lockfile_location=lockfile_location,
+            debug=debug,
+            process_count=process_count,
+            batch_size=batch_size,
+            lock_file_name=lock_file_name,
         )
         self.recursive = recursive
         self.clear = clear


### PR DESCRIPTION
## 📥 Pull Request Description

To be more flexible in the configuration of a `FileChecksumProcessor` a lock file name can now be specified. The default value is `lock.yaml`. 

## 👀 Affected Areas

- `FileChecksumProcessor` and its subclasses

## 📝 Checklist

Please make sure you've completed the following tasks before submitting this pull request:

- [X] Pre-commit hooks were executed
- [ ] Changes have been reviewed by at least one other developer
- [X] Tests have been added or updated to cover the changes (only necessary if the changes affect the executable code)
- [ ] Documentation has been updated to reflect the changes - **Not necessary**
- [ ] Any necessary migrations have been run - **Not necessary**

## 📌 Related Issues

*None*

## 🔗 Links

*None*
## 📷 Screenshots

*None*
