### PR TITLE
fix: import type of load_img_uint8

### DIFF
--- a/niceml/utilities/imageloading.py
+++ b/niceml/utilities/imageloading.py
@@ -1,7 +1,7 @@
 """Module for image loading"""
 from os.path import basename, join
 from tempfile import TemporaryDirectory
-from typing import Optional
+from typing import Optional, Union
 
 import cv2
 import numpy as np
@@ -10,10 +10,11 @@ from fsspec.implementations.local import LocalFileSystem
 from PIL import Image
 
 from niceml.utilities.imagesize import ImageSize
+from niceml.utilities.fsspec.locationutils import LocationConfig
 
 
 def load_img_uint8(
-    image_path: str,
+    image_path: Union[str, LocationConfig],
     file_system: Optional[AbstractFileSystem] = None,
     target_image_size: Optional[ImageSize] = None,
     interpolation: int = cv2.INTER_LINEAR,
@@ -32,6 +33,8 @@ def load_img_uint8(
     """
     file_system: AbstractFileSystem = file_system or LocalFileSystem()
     try:
+        if type(image_path) == LocationConfig:
+            image_path = image_path.uri
         with file_system.open(image_path) as fs_file:
             image = Image.open(fs_file).copy()
         np_array = np.array(image)


### PR DESCRIPTION
## 📥 Pull Request Description

load_img_uint8 did not work if image_path is not str but LocationConfig type.

## 👀 Affected Areas

imageloading.py

## 📝 Checklist

Please make sure you've completed the following tasks before submitting this pull request:

- [x] Pre-commit hooks were executed
- [ ] Changes have been reviewed by at least one other developer
- [ ] Tests have been added or updated to cover the changes (only necessary if the changes affect the executable code)
- [ ] All tests ran successfully
- [ ] All merge conflicts are resolved
- [ ] Documentation has been updated to reflect the changes
- [ ] Any necessary migrations have been run

## 📌 Related Issues

If this pull request is related to an existing issue, please reference it here.

## 🔗 Links

Please provide any relevant links (e.g. documentation, external resources) that support your changes.

## 📷 Screenshots

If applicable, please include screenshots of the before and after effects of your changes.

Thank you for your contribution! 🎉
