### PR TITLE
Feature/join location with path objects

### DIFF
--- a/niceml/utilities/fsspec/locationutils.py
+++ b/niceml/utilities/fsspec/locationutils.py
@@ -40,7 +40,7 @@ class LocationConfig:  # pylint: disable=too-few-public-methods
 def join_location_w_path(
     location: Union[LocationConfig, dict], path: Union[List[str], str]
 ) -> LocationConfig:
-    """Returns joined path to a LocationConfig"""
+    """Returns joined LocationConfig with one or more path objects"""
     parsed_config = (
         location
         if isinstance(location, LocationConfig)

--- a/niceml/utilities/fsspec/locationutils.py
+++ b/niceml/utilities/fsspec/locationutils.py
@@ -2,7 +2,7 @@
 from contextlib import contextmanager
 from copy import deepcopy
 from os.path import join
-from typing import Any, Dict, Iterator, Tuple, Union
+from typing import Any, Dict, Iterator, Tuple, Union, List
 
 import cattr
 from attr import asdict
@@ -38,7 +38,7 @@ class LocationConfig:  # pylint: disable=too-few-public-methods
 
 
 def join_location_w_path(
-    location: Union[LocationConfig, dict], path: str
+    location: Union[LocationConfig, dict], path: Union[List[str], str]
 ) -> LocationConfig:
     """Returns joined path to a LocationConfig"""
     parsed_config = (
@@ -48,7 +48,11 @@ def join_location_w_path(
     )
     copied_config = deepcopy(parsed_config)
     # TODO: check how to get the correct separator from the filesystem
-    copied_config.uri = join(copied_config.uri, path)
+    if isinstance(path, list):
+        for path_obj in path:
+            copied_config.uri = join(copied_config.uri, path_obj)
+    else:
+        copied_config.uri = join(copied_config.uri, path)
     return copied_config
 
 

--- a/tests/unit/niceml/utilities/test_locationutils.py
+++ b/tests/unit/niceml/utilities/test_locationutils.py
@@ -16,8 +16,11 @@ def test_join_fs_path():
     filepath = "path/to/file"
     old_config = LocationConfig(uri=s3_path, fs_args={"an_arg": "value"})
     new_config = join_location_w_path(old_config, filepath)
+    new_config_multiple = join_location_w_path(old_config, ["foldername", filepath])
     assert new_config.uri == join(s3_path, filepath)
     assert new_config.fs_args == old_config.fs_args
+    assert new_config_multiple.uri == join(s3_path, "foldername", filepath)
+    assert new_config_multiple.fs_args == old_config.fs_args
     assert old_config.uri == s3_path
 
 


### PR DESCRIPTION
## 📥 Pull Request Description

'join_location_w_path' now accepts a list of path objects, which will be joined to the location. This way, one can now join a location with a subfolder and its file in one step instead of having to call the function multiple times.
The original functionality remains intact.

## 👀 Affected Areas

All areas where a location is joined with a path can now profit from the change.

## 📝 Checklist

Please make sure you've completed the following tasks before submitting this pull request:

- [x] Pre-commit hooks were executed
- [x] Changes have been reviewed by at least one other developer
- [x] Tests have been added or updated to cover the changes (only necessary if the changes affect the executable code)
- [x] All tests ran successfully
- [x] All merge conflicts are resolved
- [x] Documentation has been updated to reflect the changes
- [x] Any necessary migrations have been run
