### PR TITLE
Feature/optimize file locks

### DIFF
--- a/niceml/utilities/readwritelock.py
+++ b/niceml/utilities/readwritelock.py
@@ -90,7 +90,7 @@ class WriteLock(FileLock):
                         f"Timeout while waiting for write lock release at"
                         f" '{write_lock_path}'"
                     )
-                logging.warning(
+                logging.info(
                     f"Waiting for write lock release {self.retry_await_time} seconds"
                 )
                 time.sleep(self.retry_time)
@@ -106,7 +106,7 @@ class WriteLock(FileLock):
                         f"Timeout while waiting for read lock release at"
                         f" '{read_lock_path}'"
                     )
-                logging.warning(
+                logging.info(
                     f"Waiting for read lock release {self.retry_await_time} seconds"
                 )
                 time.sleep(self.retry_time)
@@ -169,7 +169,7 @@ class ReadLock(FileLock):
                         f"'{write_lock_path}' to acquire read lock at "
                         f"'{read_lock_path}'"
                     )
-                logging.warning(
+                logging.info(
                     f"Waiting for write lock release {self.retry_await_time} "
                     f"seconds, to acquire read lock."
                 )

--- a/niceml/utilities/readwritelock.py
+++ b/niceml/utilities/readwritelock.py
@@ -64,13 +64,12 @@ class WriteLock(FileLock):
         """Initialize WriteLock"""
         if write_lock_name == read_lock_name:
             raise ValueError("write_lock_name and read_lock_name must be different")
-        super().__init__(retry_time, timeout)
+        super().__init__(retry_time, timeout, is_acquired)
         self.path_config = path_config
         self.write = write
         self.write_lock_name = write_lock_name
         self.read_lock_name = read_lock_name
         self.retry_await_time = retry_await_time
-        self.is_acquired = is_acquired
 
     def acquire(self):
         """Acquire the lock"""
@@ -144,12 +143,11 @@ class ReadLock(FileLock):
         """Initialize ReadLock"""
         if write_lock_name == read_lock_name:
             raise ValueError("write_lock_name and read_lock_name must be different")
-        super().__init__(retry_time, timeout)
+        super().__init__(retry_time, timeout, is_acquired)
         self.path_config = path_config
         self.write_lock_name = write_lock_name
         self.read_lock_name = read_lock_name
         self.retry_await_time = retry_await_time
-        self.is_acquired = is_acquired
 
     def acquire(self):
         """Acquire the lock"""

--- a/template/configs/ops/train/op_train_semseg.yaml
+++ b/template/configs/ops/train/op_train_semseg.yaml
@@ -46,7 +46,6 @@ learner:
     optimizer:
       _target_: tensorflow.keras.optimizers.RMSprop
       learning_rate: 0.0001
-      decay: 0.000001
     metrics:
       - _target_: niceml.dlframeworks.tensorflow.kerasmetrics.MeanIoU
       - _target_: niceml.dlframeworks.tensorflow.metrics.semsegmetrics.AvgPosPredSemSeg


### PR DESCRIPTION
## 📥 Pull Request Description

The 'is_acquired' parameter of FileLocks can now be set when the Lock is initialized. This can be necessary, if a FileLock file is already present, but the according FileLock object is not. This may happen, if a FileLock could not have been released e.g. due to an error.

Additionally, an outdated config was removed from a template configuration.

## 👀 Affected Areas

Everywhere a FileLock is used.

## 📝 Checklist

Please make sure you've completed the following tasks before submitting this pull request:

- [x] Pre-commit hooks were executed
- [ ] Changes have been reviewed by at least one other developer
- [ ] Tests have been added or updated to cover the changes (only necessary if the changes affect the executable code)
- [ ] All tests ran successfully
- [x] All merge conflicts are resolved
- [ ] Documentation has been updated to reflect the changes
- [ ] Any necessary migrations have been run

