### PR TITLE
fix: Return the experiment path instead of the experiment 

### DIFF
--- a/niceml/experiments/experimenterrors.py
+++ b/niceml/experiments/experimenterrors.py
@@ -25,7 +25,7 @@ class ExperimentNotFoundError(Exception):
     """Error when the path doesn't contain an experiment"""
 
 
-class MultipleExperimentFoundError(Exception):
+class MultipleExperimentsFoundError(Exception):
     """Error when the path contain multiple experiment with a given id"""
 
 

--- a/niceml/experiments/experimenterrors.py
+++ b/niceml/experiments/experimenterrors.py
@@ -25,5 +25,9 @@ class ExperimentNotFoundError(Exception):
     """Error when the path doesn't contain an experiment"""
 
 
+class MultipleExperimentFoundError(Exception):
+    """Error when the path contain multiple experiment with a given id"""
+
+
 class AmbigousFilenameError(Exception):
     """Filename can be interpreted in multiple ways"""

--- a/niceml/experiments/exppathfinder.py
+++ b/niceml/experiments/exppathfinder.py
@@ -4,7 +4,7 @@ from typing import List
 from niceml.data.storages.fsspecstorage import FSSpecStorage
 from niceml.experiments.experimenterrors import (
     ExperimentNotFoundError,
-    MultipleExperimentFoundError,
+    MultipleExperimentsFoundError,
 )
 from niceml.experiments.experimentinfo import ExperimentInfo
 from niceml.utilities.fsspec.locationutils import LocationConfig
@@ -24,7 +24,7 @@ def get_exp_filepath(fs_path_config: LocationConfig, exp_id: str):
             f"Experiment with id: {exp_id} not found in path: {fs_path_config.uri}"
         )
     if len(exps_w_id) > 1:
-        raise MultipleExperimentFoundError(
+        raise MultipleExperimentsFoundError(
             f"Multiple experiments with id: {exp_id} found in path: {fs_path_config.uri}"
         )
     return exps_w_id[0].exp_filepath

--- a/niceml/experiments/exppathfinder.py
+++ b/niceml/experiments/exppathfinder.py
@@ -24,4 +24,4 @@ def get_exp_filepath(fs_path_config: LocationConfig, exp_id: str):
         raise ExperimentNotFoundError(
             f"Multiple experiments with id: {exp_id} found in path: {fs_path_config.uri}"
         )
-    return exps_w_id[0]
+    return exps_w_id[0].exp_filepath

--- a/niceml/experiments/exppathfinder.py
+++ b/niceml/experiments/exppathfinder.py
@@ -2,7 +2,10 @@
 from typing import List
 
 from niceml.data.storages.fsspecstorage import FSSpecStorage
-from niceml.experiments.experimenterrors import ExperimentNotFoundError
+from niceml.experiments.experimenterrors import (
+    ExperimentNotFoundError,
+    MultipleExperimentFoundError,
+)
 from niceml.experiments.experimentinfo import ExperimentInfo
 from niceml.utilities.fsspec.locationutils import LocationConfig
 
@@ -21,7 +24,7 @@ def get_exp_filepath(fs_path_config: LocationConfig, exp_id: str):
             f"Experiment with id: {exp_id} not found in path: {fs_path_config.uri}"
         )
     if len(exps_w_id) > 1:
-        raise ExperimentNotFoundError(
+        raise MultipleExperimentFoundError(
             f"Multiple experiments with id: {exp_id} found in path: {fs_path_config.uri}"
         )
     return exps_w_id[0].exp_filepath

--- a/tests/unit/niceml/experiments/test_exppathfinder.py
+++ b/tests/unit/niceml/experiments/test_exppathfinder.py
@@ -4,7 +4,7 @@ from typing import Union
 import pytest
 
 from niceml.experiments.experimenterrors import (
-    MultipleExperimentFoundError,
+    MultipleExperimentsFoundError,
     ExperimentNotFoundError,
 )
 from niceml.experiments.experimentinfo import ExperimentInfo
@@ -62,12 +62,12 @@ def exp_location(
     "exp_id,expected",
     [
         ("abcd", "abcd"),
-        ("efgh", MultipleExperimentFoundError),
+        ("efgh", MultipleExperimentsFoundError),
         ("ijkl", ExperimentNotFoundError),
     ],
 )
 def test_get_exp_filepath(exp_location, exp_id: str, expected: Union[str, Exception]):
-    if isinstance(expected, type):
+    if expected in [MultipleExperimentsFoundError, ExperimentNotFoundError]:
         with pytest.raises(expected):
             get_exp_filepath(fs_path_config=exp_location, exp_id=exp_id)
     else:

--- a/tests/unit/niceml/experiments/test_exppathfinder.py
+++ b/tests/unit/niceml/experiments/test_exppathfinder.py
@@ -1,0 +1,76 @@
+import datetime
+from typing import Union
+
+import pytest
+
+from niceml.experiments.experimenterrors import (
+    MultipleExperimentFoundError,
+    ExperimentNotFoundError,
+)
+from niceml.experiments.experimentinfo import ExperimentInfo
+from niceml.experiments.expfilenames import ExperimentFilenames
+from niceml.experiments.exppathfinder import get_exp_filepath
+from niceml.utilities.fsspec.locationutils import (
+    LocationConfig,
+    open_location,
+    join_fs_path,
+    join_location_w_path,
+)
+from niceml.utilities.ioutils import write_yaml
+
+
+@pytest.fixture
+def exp_location(
+    tmp_dir,
+) -> LocationConfig:
+    location_config = LocationConfig(uri=tmp_dir)
+    exp_ids = ["abcd", "efgh", "efgh"]
+    test_prefix = "TEST"
+    with open_location(location_config) as (exps_fs, exps_root):
+        for exp_id in exp_ids:
+            date = datetime.datetime.utcnow()
+            date_string = date.strftime("%Y-%m-%dT%H.%M.%S.%fZ")
+            exp_filepath = join_fs_path(
+                exps_fs, exps_root, f"{test_prefix}-{date_string}-id_{exp_id}"
+            )
+            exps_fs.mkdir(exp_filepath)
+            exp_info = ExperimentInfo(
+                experiment_prefix=test_prefix,
+                experiment_name="test",
+                experiment_type="",
+                run_id=date_string,
+                short_id=exp_id,
+                environment={},
+                description="",
+                exp_dir="",
+            )
+            with open_location(join_location_w_path(location_config, exp_filepath)) as (
+                exp_fs,
+                exp_root,
+            ):
+                write_yaml(
+                    data=exp_info.as_save_dict(),
+                    filepath=join_fs_path(
+                        exp_fs, exp_root, ExperimentFilenames.EXP_INFO
+                    ),
+                )
+
+    return location_config
+
+
+@pytest.mark.parametrize(
+    "exp_id,expected",
+    [
+        ("abcd", "abcd"),
+        ("efgh", MultipleExperimentFoundError),
+        ("ijkl", ExperimentNotFoundError),
+    ],
+)
+def test_get_exp_filepath(exp_location, exp_id: str, expected: Union[str, Exception]):
+    if isinstance(expected, type):
+        with pytest.raises(expected):
+            get_exp_filepath(fs_path_config=exp_location, exp_id=exp_id)
+    else:
+        exp_filepath = get_exp_filepath(fs_path_config=exp_location, exp_id=exp_id)
+
+        assert expected == exp_filepath[-4:]


### PR DESCRIPTION
## 📥 Pull Request Description

There was a bug that the `get_exp_filepath` function returns an`ExperimentInfo` instead of the experiment file path if the exp_id is something else than "latest". This is fixed with this pull request.

## 👀 Affected Areas

- eval pipeline --> load experiment 

## 📝 Checklist

Please make sure you've completed the following tasks before submitting this pull request:

- [x] Pre-commit hooks were executed
- [x] Changes have been reviewed by at least one other developer
- [x] Tests have been added or updated to cover the changes (only necessary if the changes affect the executable code)
- [x] All tests ran successfully
- [x] All merge conflicts are resolved
- [ ] Documentation has been updated to reflect the changes
- [ ] Any necessary migrations have been run

## 📌 Related Issues

_None_

## 🔗 Links

_None_

## 📷 Screenshots

_None_