### PR TITLE
fix: remove job flag to prevent multiple mlflow runs

### DIFF
--- a/niceml/dagster/jobs/jobs.py
+++ b/niceml/dagster/jobs/jobs.py
@@ -1,5 +1,5 @@
 """Module containing all dagster jobs"""
-from dagster_mlflow import mlflow_tracking, end_mlflow_on_run_finished
+from dagster_mlflow import mlflow_tracking
 
 from niceml.config.hydra import hydra_conf_mapping_factory
 from niceml.dagster.ops.analysis import analysis
@@ -35,7 +35,6 @@ def job_data_generation():
     df_normalization(current_data_location)
 
 
-@end_mlflow_on_run_finished
 @job(config=hydra_conf_mapping_factory(), resource_defs={"mlflow": mlflow_tracking})
 def job_train():
     """Job for training an experiment"""
@@ -54,7 +53,6 @@ def job_train():
     exptests(exp_context)  # pylint: disable=no-value-for-parameter
 
 
-@end_mlflow_on_run_finished
 @job(config=hydra_conf_mapping_factory(), resource_defs={"mlflow": mlflow_tracking})
 def job_eval():
     """Job for evaluating experiment"""


### PR DESCRIPTION
## 📥 Pull Request Description

This pull request fixes a bug, which created two experiment runs out of one dagster pipeline run. This is a bug, caused by the dagster itegration of MLFlow. The implementation in niceML was correct. When the bug of this package is fixed in the future, niceML may has to be updated as well.
With this fix, niceML, dagster and MLFlow work and only one MLFlow experiment run is created per dagster pipeline run.

## 👀 Affected Areas

Dagster Pipeline
MLFlow integration

## 📝 Checklist

Please make sure you've completed the following tasks before submitting this pull request:

- [x] Pre-commit hooks were executed
- [ ] Changes have been reviewed by at least one other developer
- [ ] Tests have been added or updated to cover the changes (only necessary if the changes affect the executable code)
- [x] All tests ran successfully
- [x] All merge conflicts are resolved
- [ ] Documentation has been updated to reflect the changes
- [ ] Any necessary migrations have been run

