### PR TITLE
Set the Python version of the release workflow to 3.10

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,10 +22,10 @@ jobs:
           ref: 'main'
           fetch-depth: 0
           token: ${{ secrets.RELEASE_WORKFLOW }}
-      - name: 🐍Setup Python ${{ matrix.python-version }}
+      - name: 🐍Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: 🔨 Setup poetry
         uses: abatilo/actions-poetry@v2.0.0
         with:


### PR DESCRIPTION
## 📥 Pull Request Description

This pull request fixes the issue that the release workflow uses the unsupported Python version 3.8. Python 3.10 is used instead.

## 👀 Affected Areas

- release pipeline

## 📝 Checklist

Please make sure you've completed the following tasks before submitting this pull request:

- [X] Pre-commit hooks were executed
- [x] Changes have been reviewed by at least one other developer
- [ ] Tests have been added or updated to cover the changes (only necessary if the changes affect the executable code)
- [X] All tests ran successfully
- [ ] All merge conflicts are resolved
- [ ] Documentation has been updated to reflect the changes
- [X] Any necessary migrations have been run

