### PR TITLE
fix: reload of old exps in dashboard

### DIFF
--- a/niceml/experiments/experimentinfo.py
+++ b/niceml/experiments/experimentinfo.py
@@ -51,9 +51,16 @@ class ExperimentInfo:
             LAST_MODIFIED_KEY: self.last_modified,
         }
 
-    def is_modified(self, other: "ExperimentInfo") -> bool:
+    def is_modified(
+        self, other: "ExperimentInfo", ignore_missing_timestamp: Optional[bool] = True
+    ) -> bool:
         """Checks if the other experiment info is modified"""
-        return self.last_modified != other.last_modified
+        if self.last_modified != other.last_modified:
+            if ignore_missing_timestamp:
+                if self.last_modified is None or other.last_modified is None:
+                    return False
+            return True
+        return False
 
 
 def load_exp_info(

--- a/niceml/experiments/experimentmanager.py
+++ b/niceml/experiments/experimentmanager.py
@@ -103,7 +103,7 @@ class ExperimentManager(object):
         if exp_info.short_id not in self.exp_dict_short_id:
             return True
         exp = self.get_exp_by_id(exp_info.short_id)
-        return exp.exp_info.is_modified(exp_info)
+        return exp_info.is_modified(exp.exp_info)
 
     def get_datasets(self) -> List[str]:
         """Returns a list of all datasets used in the experiments"""


### PR DESCRIPTION
## 📥 Pull Request Description

Old experiments (without 'is_modified' information) are detected as modified by the 'ExperimentInfo.is_modified' function, because their timestamp is none, but when these experiments are cached, their timestamp for 'is_modified' is set.
An optional argument was added, to count these experiments as not modified, if their timestamp is none.

## 👀 Affected Areas

- Dashboard
- Experiment reloading

## 📝 Checklist

Please make sure you've completed the following tasks before submitting this pull request:

- [x] Pre-commit hooks were executed
- [ ] Changes have been reviewed by at least one other developer
- [ ] Tests have been added or updated to cover the changes (only necessary if the changes affect the executable code)
- [x] All tests ran successfully
- [x] All merge conflicts are resolved
- [x] Documentation has been updated to reflect the changes
- [ ] Any necessary migrations have been run

