### PR TITLE
Fix `prerelease` flag in pre-release pipeline 

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: 🐍Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: 🔨 Setup poetry
         uses: abatilo/actions-poetry@v2.0.0
         with:

--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: python-semantic-release/python-semantic-release@v8.7.0
         with:
           github_token: ${{ secrets.RELEASE_WORKFLOW }}
-          force: "prerelease"
+          prerelease: 'true'
 
       - name: 🐍 Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.14

--- a/niceml/experiments/experimentcontext.py
+++ b/niceml/experiments/experimentcontext.py
@@ -128,11 +128,20 @@ class ExperimentContext:
             return read_json(join(root_path, data_path), file_system=file_system)
 
     def write_image(
-        self, image: Image.Image, data_path: str, apply_last_modified: bool = True
+        self,
+        image: Image.Image,
+        data_path: str,
+        apply_last_modified: bool = True,
+        **kwargs,
     ):
         """Writes an image relative to the experiment"""
         with open_location(self.fs_config) as (file_system, root_path):
-            write_image(image, join(root_path, data_path), file_system=file_system)
+            write_image(
+                image,
+                join(root_path, data_path),
+                file_system=file_system,
+                **kwargs,
+            )
         if apply_last_modified:
             self.update_last_modified()
 


### PR DESCRIPTION
## 📥 Pull Request Description

This pull request fixes the pre-release pipeline. 
In addition, the Python version of the Docs pipeline has been updated and the `write_image` function now allows `kwargs`.

## 👀 Affected Areas

- Pre-release pipeline
- docs pipeline
- ioutils

## 📝 Checklist

Please make sure you've completed the following tasks before submitting this pull request:

- [X] Pre-commit hooks were executed
- [ ] Changes have been reviewed by at least one other developer
- [ ] Tests have been added or updated to cover the changes (only necessary if the changes affect the executable code)
- [X] All tests ran successfully
- [X] All merge conflicts are resolved
- [ ] Documentation has been updated to reflect the changes
- [X] Any necessary migrations have been run

